### PR TITLE
Vite: Disable SourceMap

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "referentiel",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "referentiel",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "license": "MIT",
       "devDependencies": {
         "@typescript-eslint/eslint-plugin": "^5.37.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "referentiel",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Convert position relative to a html element.",
   "main": "dist/referentiel.umd.js",
   "types": "dist/referentiel.d.ts",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,8 +15,8 @@
     "experimentalDecorators": true,
     "emitDecoratorMetadata": true,
     "noUncheckedIndexedAccess": true,
-    "sourceMap": true,
-    "inlineSources": true,
+    "sourceMap": false,
+    "inlineSources": false,
     "baseUrl": ".",
     "esModuleInterop": true
   },


### PR DESCRIPTION
On Vite, we are getting this error:

```
node_modules/referentiel/dist/referentiel.js (11:28): Error when using sourcemap for reporting an error: Can't resolve original location of error.
```